### PR TITLE
Show the portrait only on About

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -187,30 +187,6 @@ a:hover { color: var(--accent); }
   line-height: 1.55;
 }
 
-.home-identity {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.home-portrait {
-  flex: 0 0 7.25rem;
-  width: 7.25rem;
-  aspect-ratio: 1;
-  display: block;
-  overflow: hidden;
-  border-radius: 50%;
-  background: var(--surface);
-  box-shadow: 0 0 0 1px var(--line);
-}
-
-.home-portrait img {
-  width: 100%;
-  height: 100%;
-  display: block;
-  object-fit: cover;
-}
-
 .home-statement {
   padding-bottom: .2rem;
 }
@@ -295,6 +271,41 @@ a:hover { color: var(--accent); }
   line-height: 1.45;
 }
 
+.about-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 10rem;
+  grid-template-areas:
+    "kicker portrait"
+    "title portrait"
+    "lead portrait";
+  column-gap: clamp(3rem, 8vw, 7rem);
+  align-items: end;
+}
+
+.about-header > .eyebrow { grid-area: kicker; }
+.about-header > h1 { grid-area: title; }
+.about-header > .page-lead { grid-area: lead; }
+
+.about-portrait {
+  grid-area: portrait;
+  width: 10rem;
+  aspect-ratio: 1;
+  align-self: center;
+  display: block;
+  overflow: hidden;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: 0 0 0 1px var(--line);
+}
+
+.about-portrait img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  object-position: 50% 42%;
+}
+
 .prose {
   max-width: var(--reading);
   margin-left: clamp(0rem, 12vw, 13rem);
@@ -370,8 +381,6 @@ a:hover { color: var(--accent); }
   .site-nav a::after { bottom: -.35rem; }
   .home-hero { min-height: auto; grid-template-columns: 1fr; gap: 4rem; padding-block: 5.5rem 4.5rem; }
   .home-intro h1 { margin-top: 1rem; font-size: clamp(3.1rem, 15.5vw, 4.65rem); }
-  .home-identity { gap: 1.25rem; }
-  .home-portrait { flex-basis: 6rem; width: 6rem; }
   .home-statement > p:first-child { font-size: 1.25rem; }
   .route-list { grid-template-columns: 1fr; }
   .route-list a, .route-list a + a { min-height: 6.25rem; padding: 1.2rem 0; border-right: 0; border-bottom: 1px solid var(--line); }
@@ -381,6 +390,15 @@ a:hover { color: var(--accent); }
   .page-shell { padding-block: 5rem 5.5rem; }
   .page-header { margin-bottom: 4.5rem; }
   .page-header h1, .error-page h1 { font-size: clamp(3rem, 15vw, 4.75rem); }
+  .about-header {
+    grid-template-columns: minmax(0, 1fr) 6.5rem;
+    grid-template-areas:
+      "kicker kicker"
+      "title portrait"
+      "lead lead";
+    column-gap: 1.5rem;
+  }
+  .about-portrait { width: 6.5rem; }
   .prose { margin-left: 0; }
   .prose h2 { margin-top: 4rem; }
   .record, .project { grid-template-columns: 1fr; gap: 1.5rem; padding-block: 3.25rem; }

--- a/content/about.md
+++ b/content/about.md
@@ -1,5 +1,6 @@
 ---
 title: About
+type: about
 kicker: Profile & contact
 lead: PhD candidate in Industrial Ecology at Leiden University's Institute of Environmental Sciences (CML).
 description: Biography, education, affiliation and contact details for Adrien Perello-y-Bestard.
@@ -25,4 +26,3 @@ Einsteinweg 2, 2333 CC Leiden, the Netherlands
 - [ORCID](https://orcid.org/0009-0006-1466-3536)
 - [GitHub](https://github.com/adrien-perello)
 - [LinkedIn](https://www.linkedin.com/in/adrien-perello-y-bestard/)
-

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -1,0 +1,31 @@
+{{ define "main" }}
+  {{ $portrait := resources.Get "images/perello-adrien-large.jpg" }}
+  {{ $portrait160 := $portrait.Resize "160x webp q82" }}
+  {{ $portrait240 := $portrait.Resize "240x webp q82" }}
+  {{ $portrait320 := $portrait.Resize "320x webp q82" }}
+  {{ $portraitFallback := $portrait.Resize "240x jpg q85" }}
+  <article class="page-shell">
+    <header class="page-header about-header">
+      {{ with .Params.kicker }}<p class="eyebrow">{{ . }}</p>{{ end }}
+      <h1>{{ .Title }}</h1>
+      {{ with .Params.lead }}<p class="page-lead">{{ . }}</p>{{ end }}
+      <picture class="about-portrait">
+        <source
+          type="image/webp"
+          srcset="{{ $portrait160.RelPermalink }} 160w, {{ $portrait240.RelPermalink }} 240w, {{ $portrait320.RelPermalink }} 320w"
+          sizes="(max-width: 760px) 6.5rem, 10rem">
+        <img
+          src="{{ $portraitFallback.RelPermalink }}"
+          width="{{ $portraitFallback.Width }}"
+          height="{{ $portraitFallback.Height }}"
+          alt="Portrait of Adrien Perello-y-Bestard"
+          loading="eager"
+          fetchpriority="high"
+          decoding="async">
+      </picture>
+    </header>
+    <div class="prose">
+      {{ .Content }}
+    </div>
+  </article>
+{{ end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,31 +1,10 @@
 {{ define "main" }}
-  {{ $portrait := resources.Get "images/perello-adrien-large.jpg" }}
-  {{ $portrait160 := $portrait.Fill "160x160 Top webp q82" }}
-  {{ $portrait240 := $portrait.Fill "240x240 Top webp q82" }}
-  {{ $portrait320 := $portrait.Fill "320x320 Top webp q82" }}
-  {{ $portraitFallback := $portrait.Fill "240x240 Top jpg q85" }}
   <div class="home-shell">
     <section class="home-hero" aria-labelledby="home-title">
       <div class="home-intro">
         <p class="eyebrow">PhD candidate · Industrial Ecology</p>
         <h1 id="home-title">Adrien<br>Perello-y-Bestard</h1>
-        <div class="home-identity">
-          <picture class="home-portrait">
-            <source
-              type="image/webp"
-              srcset="{{ $portrait160.RelPermalink }} 160w, {{ $portrait240.RelPermalink }} 240w, {{ $portrait320.RelPermalink }} 320w"
-              sizes="(max-width: 760px) 6rem, 7.25rem">
-            <img
-              src="{{ $portraitFallback.RelPermalink }}"
-              width="{{ $portraitFallback.Width }}"
-              height="{{ $portraitFallback.Height }}"
-              alt="Portrait of Adrien Perello-y-Bestard"
-              loading="eager"
-              fetchpriority="high"
-              decoding="async">
-          </picture>
-          <p class="affiliation">Institute of Environmental Sciences (CML)<br>Leiden University</p>
-        </div>
+        <p class="affiliation">Institute of Environmental Sciences (CML)<br>Leiden University</p>
       </div>
       <div class="home-statement">
         <p>I study how incomplete and changing technical evidence can become trustworthy, reviewable prospective life-cycle models early enough to support Safe-and-Sustainable-by-Design decisions for chemicals and materials.</p>


### PR DESCRIPTION
## Summary

This follow-up removes the profile picture from the landing page and displays it only on the About page.

- restores the homepage to a fully typographic, image-free composition;
- adds an About-specific layout with the circular portrait beside the page heading;
- keeps the portrait at 10 rem on desktop and 6.5 rem on mobile;
- uses a slightly raised image crop inside the circle (`object-position: 50% 42%`) so the top of the head sits closer to the upper edge without clipping;
- retains responsive 160, 240, and 320 px WebP derivatives plus a JPEG fallback generated by Hugo;
- keeps alternative text, intrinsic dimensions, and responsive sizing.

## Design rationale

The portrait is useful biographical context on About, but it competes with the landing page's intentionally sparse identity-and-research composition. Restricting it to About preserves the first viewport's visual restraint while keeping a human profile cue where visitors expect biographical information.

On desktop, the portrait sits to the right of the About heading and lead. On mobile, it shares the title row and the lead returns to full width below. No card or rectangular image frame is introduced.

## Validation

Run with Hugo `0.165.0`:

```sh
hugo --gc --minify
python3 scripts/check_site.py public
git diff --check
```

Results:

- production build succeeded with no Hugo warnings;
- all six generated HTML pages passed the site checker;
- the homepage contains no `img`, `picture`, or portrait-resource reference;
- the About page generates the expected responsive WebP sources and JPEG fallback;
- desktop review at 1363 × 936 confirmed the portrait is contained within the About header;
- mobile review at 375 CSS pixels confirmed no horizontal overflow and a coherent title/portrait row;
- the adjusted crop leaves a small margin above the hairline without clipping;
- no site-origin browser warnings or errors were observed.

## Review guide

Please compare:

1. the restored image-free homepage;
2. the About header on desktop;
3. the About title and portrait at mobile width;
4. the slightly tighter crop at the top of the circular portrait.